### PR TITLE
EventEmitter .emit and .on, Browser and feature detection for #56 #60 #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Meething is a semi-decentralized conference bridge using modern WebRTC, [GunDB](http://gun.eco) and NodeJS
 
-<img src="https://user-images.githubusercontent.com/1423657/78457103-3260a800-76a8-11ea-8c7a-c909c88ba716.png" width=600>
+<img src="https://user-images.githubusercontent.com/1423657/78457103-3260a800-76a8-11ea-8c7a-c909c88ba716.png" width=400>
 
 ## Status
 * Working Status, _still dWeb-x-perimental!_
@@ -32,7 +32,12 @@ The Meething  application will connect to community Gun nodes for user discovery
 
 
 ### SuperPeers
-SuperPeers can provide the network with services such as STUN/TURN/RELAY and in the future SFU/MCU features.
+SuperPeers can provide the network with services such as STUN/TURN/RELAY and in the future SFU/MCU features. For more details, check out the Project Wiki.
+
+--------------
+
+## Screenshots
+
 
 #### Isolation Test @qxip @amark @qvdev
 <img src="https://user-images.githubusercontent.com/1423657/77968595-04661700-72e8-11ea-8226-b90fbe8011c8.png" width=500 />

--- a/src/assets/js/emitter.js
+++ b/src/assets/js/emitter.js
@@ -18,7 +18,7 @@ export default class EventEmitter {
     this.presence = presence;
   }
   getPresence(){
-    return this.presence ? this.precense : false;
+    return this.presence ? this.presence : false;
   }
   emit(event,data){
     console.log("emitting event",event,"with data",data);

--- a/src/assets/js/emitter.js
+++ b/src/assets/js/emitter.js
@@ -1,6 +1,7 @@
 export default class EventEmitter {
   constructor(gun, room) {
     this.listeners = {};
+    this.presence = null;
     this.room = room;
     this.root = gun;
     this.init();
@@ -12,6 +13,12 @@ export default class EventEmitter {
     //Object.assign(this,{[event]:this.listeners[event]});
     console.log("added on event",event,"callback",cb,this);
     return this;
+  }
+  setPresence(presence){
+    this.presence = presence;
+  }
+  getPresence(){
+    return this.presence ? this.precense : false;
   }
   emit(event,data){
     console.log("emitting event",event,"with data",data);
@@ -33,11 +40,11 @@ export default class EventEmitter {
     this.pid = this.root._.opt.pid;
 
     this.root.on("in", function (msg) {
-      /*if (msg && msg.event && self.presence && self.presence.handleADamEvents) {
-        self.presence.handleADamEvents(msg);
+      if (msg && msg.event && self.getPresence()) {
+        let presence = self.getPresence();
+        if(presence) presence.handleADamEvents(msg);
       }
-      else */
-      if (msg && msg.signaling) {
+      else if (msg && msg.signaling) {
         console.log(
           "DAM: handle inbound signaling!",
           msg.signaling + " for room " + msg.data.room

--- a/src/assets/js/emitter.js
+++ b/src/assets/js/emitter.js
@@ -11,7 +11,7 @@ export default class EventEmitter {
     if(!this.listeners[event]) this.listeners[event] = [];
     this.listeners[event].push(cb);
     //Object.assign(this,{[event]:this.listeners[event]});
-    console.log("added on event",event,"callback",cb,this);
+    //console.log("added on event",event,"callback",cb,this);
     return this;
   }
   setPresence(presence){
@@ -21,7 +21,7 @@ export default class EventEmitter {
     return this.presence ? this.presence : false;
   }
   emit(event,data){
-    console.log("emitting event",event,"with data",data);
+    //console.log("emitting event",event,"with data",data);
     let cbs = this.listeners[event];
     if(cbs){
       cbs.forEach(cb => cb(data))
@@ -45,39 +45,39 @@ export default class EventEmitter {
         if(presence) presence.handleADamEvents(msg);
       }
       else if (msg && msg.signaling) {
-        console.log(
+        /*console.log(
           "DAM: handle inbound signaling!",
           msg.signaling + " for room " + msg.data.room
-        );
+        );*/
         if (msg.data.room == self.room) {
           switch (msg.signaling) {
             case "subscribe":
               if (msg.data.socketId) {
-                console.log("DAM: subscribe from", msg.data.socketId);
+               // console.log("DAM: subscribe from", msg.data.socketId);
                 self.emit('Subscribe',msg.data);
               }
               break;
             case "newUserStart":
-              console.log("DAM: newUserStart " + msg.data);
+             // console.log("DAM: newUserStart " + msg.data);
               self.emit('NewUserStart',msg.data);
               break;
             case "icecandidates":
-              console.log("DAM: icecandidates");
+            //  console.log("DAM: icecandidates");
               self.emit('IceCandidates', msg.data);
               break;
             case "sdp":
-              console.log("DAM: sdp");
+            //  console.log("DAM: sdp");
               self.emit('SDP',msg.data);
               break;
             default:
-              console.log("DAM: Unknown signaling " + msg.signaling);
+           //   console.log("DAM: Unknown signaling " + msg.signaling);
               break;
           }
         } else {
           console.error("Should never happen privacy issue we got msg for other room " + msg.data.room);
         }
         if (msg.to && msg.to == this.pid) {
-          console.log("DAM: signaling for our local peer!", msg.data);
+        //  console.log("DAM: signaling for our local peer!", msg.data);
         }
       }
     });

--- a/src/assets/js/emitter.js
+++ b/src/assets/js/emitter.js
@@ -1,10 +1,26 @@
 export default class EventEmitter {
   constructor(gun, room) {
+    this.listeners = {};
     this.room = room;
     this.root = gun;
     this.init();
+    return this;
   }
-
+  on(event,cb){
+    if(!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(cb);
+    //Object.assign(this,{[event]:this.listeners[event]});
+    console.log("added on event",event,"callback",cb,this);
+    return this;
+  }
+  emit(event,data){
+    console.log("emitting event",event,"with data",data);
+    let cbs = this.listeners[event];
+    if(cbs){
+      cbs.forEach(cb => cb(data))
+    }
+    return this;
+  }
   //Posible signaling events
   /*
   subscribe
@@ -17,10 +33,11 @@ export default class EventEmitter {
     this.pid = this.root._.opt.pid;
 
     this.root.on("in", function (msg) {
-      if (msg && msg.event && self.presence) {
+      /*if (msg && msg.event && self.presence && self.presence.handleADamEvents) {
         self.presence.handleADamEvents(msg);
       }
-      else if (msg && msg.signaling) {
+      else */
+      if (msg && msg.signaling) {
         console.log(
           "DAM: handle inbound signaling!",
           msg.signaling + " for room " + msg.data.room
@@ -30,20 +47,20 @@ export default class EventEmitter {
             case "subscribe":
               if (msg.data.socketId) {
                 console.log("DAM: subscribe from", msg.data.socketId);
-                self.onSubscribe(msg.data);
+                self.emit('Subscribe',msg.data);
               }
               break;
             case "newUserStart":
               console.log("DAM: newUserStart " + msg.data);
-              self.onNewUserStart(msg.data);
+              self.emit('NewUserStart',msg.data);
               break;
             case "icecandidates":
               console.log("DAM: icecandidates");
-              self.onIceCandidates(msg.data);
+              self.emit('IceCandidates', msg.data);
               break;
             case "sdp":
               console.log("DAM: sdp");
-              self.onSdp(msg.data);
+              self.emit('SDP',msg.data);
               break;
             default:
               console.log("DAM: Unknown signaling " + msg.signaling);
@@ -57,6 +74,7 @@ export default class EventEmitter {
         }
       }
     });
+    return this;
   }
 
   out(key, value) {

--- a/src/assets/js/events.js
+++ b/src/assets/js/events.js
@@ -1,6 +1,6 @@
 import helpers from './helpers.js';
 
-window.addEventListener('load', () => {
+window.addEventListener('DOMContentLoaded', () => {
     //When the chat icon is clicked
     document.querySelector('#toggle-chat-pane').addEventListener('click', (e) => {
         document.querySelector('#chat-pane').classList.toggle('chat-opened');
@@ -26,24 +26,27 @@ window.addEventListener('load', () => {
 
 
     //When the video frame is clicked. This will enable picture-in-picture
-    document.getElementById('local').addEventListener('click', () => {
-        if (!document.pictureInPictureElement) {
-            document.getElementById('local').requestPictureInPicture()
-                .catch(error => {
-                    // Video failed to enter Picture-in-Picture mode.
-                    console.error(error);
-                });
-        }
+    if ("pictureInPictureEnabled" in document 
+      && typeof document.getElementById('local').requestPictureInPicture === 'function' ) 
+      {
+        document.getElementById('local').addEventListener('click', () => {
+            if (!document.pictureInPictureElement) {
+                document.getElementById('local').requestPictureInPicture()
+                    .catch(error => {
+                        // Video failed to enter Picture-in-Picture mode.
+                        console.error(error);
+                    });
+            }
 
-        else {
-            document.exitPictureInPicture()
-                .catch(error => {
-                    // Video failed to leave Picture-in-Picture mode.
-                    console.error(error);
-                });
-        }
-    });
-
+            else {
+                document.exitPictureInPicture()
+                    .catch(error => {
+                        // Video failed to leave Picture-in-Picture mode.
+                        console.error(error);
+                    });
+            }
+        });
+      }
 
     //When the 'Create room" is button is clicked
     document.getElementById('create-room').addEventListener('click', (e) => {

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -10,6 +10,7 @@ var cache,
   isOldEdge = /Edge\/1(\d)/.test(navigator.userAgent),
   isTouchScreen = ("ontouchstart" in document.documentElement) ? true : false,
   isiOS = (['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0) ? true : false,
+  isSafari = /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor),
   isMobile = (window.orientation > -1) ? true :false,
   typeOf = function(o) {
     return Object.prototype.toString
@@ -119,6 +120,9 @@ export default {
   },
   isTouchScreen(){
     return isTouchScreen;
+  },
+  isSafari(){
+    return isSafari;
   },
   isiOS(){
     return isiOS;

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -155,12 +155,14 @@ export default {
     if(window.innerHeight && window.innerWidth){
       if(window.innerHeight > window.innerWidth ) return "portrait"; 
       else return "landscape"; 
-    } else { // we shouldn't reach here but if we do, let's have matchMedia do the work
+    } else if (window.matchMedia) { // we shouldn't reach here but if we do, let's have matchMedia do the work
       var mql = window.matchMedia("(orientation: portrait)");
       if(mql && mql.matches) return "portrait";
       else return "landscape";
+    } else {
+      return "unknown";
     }
-  }, 
+  },
   typeOf(...args){
     return typeOf(...args);
   },

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -160,7 +160,7 @@ export default {
       if(mql && mql.matches) return "portrait";
       else return "landscape";
     } else {
-      return "unknown";
+      return "landscape";
     }
   },
   typeOf(...args){

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -8,6 +8,7 @@ var cache,
   MutedStream,
   isEdge = /Edge\/(\d+)(\d+)/.test(navigator.userAgent),
   isOldEdge = /Edge\/1(\d)/.test(navigator.userAgent),
+  isiOS = (['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0) ? true : false,
   canCaptureStream = (document.createElement('canvas').captureStream && typeof document.createElement('canvas').captureStream === "function") ? true : false,
   canCreateMediaStream = ('MediaStream' in window) ? true : false,
   canPlayType = document.createElement("video").canPlayType,canplaymp4,canplayogv,canplaywebm;
@@ -106,6 +107,9 @@ export default {
   },
   isOldEdge(){
     return isOldEdge;
+  },
+  isiOS(){
+    return isiOS;
   },
   canCreateMediaStream(){
     return canCreateMediaStream;

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -151,6 +151,16 @@ export default {
   canplaywebm(){
     return canplaywebm;
   },
+  getOrientation(){
+    if(window.innerHeight && window.innerWidth){
+      if(window.innerHeight > window.innerWidth ) return "portrait"; 
+      else return "landscape"; 
+    } else { // we shouldn't reach here but if we do, let's have matchMedia do the work
+      var mql = window.matchMedia("(orientation: portrait)");
+      if(mql && mql.matches) return "portrait";
+      else return "landscape";
+    }
+  }, 
   typeOf(...args){
     return typeOf(...args);
   },

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -108,7 +108,7 @@ export default {
     return isOldEdge;
   },
   canCreateMediaStream(){
-    return canUseMediaStream;
+    return canCreateMediaStream;
   },
   canCaptureStream(){
     return canCaptureStream;

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -9,6 +9,7 @@ var cache,
   isEdge = /Edge\/(\d+)(\d+)/.test(navigator.userAgent),
   isOldEdge = /Edge\/1(\d)/.test(navigator.userAgent),
   isiOS = (['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0) ? true : false,
+  isMobile = (window.orientation > -1) ? true :false,
   typeOf = function(o) {
     return Object.prototype.toString
       .call(o).match(/(\w+)\]/)[1].toLowerCase();
@@ -117,6 +118,12 @@ export default {
   },
   isiOS(){
     return isiOS;
+  },
+  isMobile(){
+    return isMobile;
+  },
+  isMobileOriOS(){
+    return (this.isMobile() || this.isiOS())?true:false;
   },
   canCreateMediaStream(){
     return canCreateMediaStream;

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -8,7 +8,7 @@ var cache,
   MutedStream,
   isEdge = /Edge\/(\d+)(\d+)/.test(navigator.userAgent),
   isOldEdge = /Edge\/1(\d)/.test(navigator.userAgent),
-  isTouchScreen = () => "ontouchstart" in document.documentElement ? true : false,
+  isTouchScreen = ("ontouchstart" in document.documentElement) ? true : false,
   isiOS = (['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0) ? true : false,
   isMobile = (window.orientation > -1) ? true :false,
   typeOf = function(o) {

--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -8,6 +8,7 @@ var cache,
   MutedStream,
   isEdge = /Edge\/(\d+)(\d+)/.test(navigator.userAgent),
   isOldEdge = /Edge\/1(\d)/.test(navigator.userAgent),
+  isTouchScreen = () => "ontouchstart" in document.documentElement ? true : false,
   isiOS = (['iPad', 'iPhone', 'iPod'].indexOf(navigator.platform) >= 0) ? true : false,
   isMobile = (window.orientation > -1) ? true :false,
   typeOf = function(o) {
@@ -115,6 +116,9 @@ export default {
   },
   isOldEdge(){
     return isOldEdge;
+  },
+  isTouchScreen(){
+    return isTouchScreen;
   },
   isiOS(){
     return isiOS;

--- a/src/assets/js/presence.js
+++ b/src/assets/js/presence.js
@@ -1,4 +1,3 @@
-
 import h from "./helpers";
 export default class Presence {
   constructor(gun, room) {

--- a/src/assets/js/presence.js
+++ b/src/assets/js/presence.js
@@ -1,10 +1,13 @@
+
+import h from "./helpers";
 export default class Presence {
   constructor(gun, room) {
     this.root = gun;
     this.room = room;
     this.pid = this.root._.opt.pid;
     this.users = new Map();
-    window.onunload = this.leave;
+    var _ev = h.isiOS() ? 'pagehide' : 'beforeunload';
+    window.addEventListener(_ev, this.leave);
   }
 
   handleADamEvents(msg) {

--- a/src/assets/js/presence.js
+++ b/src/assets/js/presence.js
@@ -1,4 +1,4 @@
-import h from "./helpers";
+import h from "./helpers.js";
 export default class Presence {
   constructor(gun, room) {
     this.root = gun;

--- a/src/assets/js/presence.js
+++ b/src/assets/js/presence.js
@@ -7,7 +7,9 @@ export default class Presence {
     this.pid = this.root._.opt.pid;
     this.users = new Map();
     var _ev = h.isiOS() ? 'pagehide' : 'beforeunload';
-    window.addEventListener(_ev, this.leave);
+    var self = this;
+    window.addEventListener(_ev, function(){self.leave();});
+    return this;
   }
 
   handleADamEvents(msg) {

--- a/src/assets/js/rtc.js
+++ b/src/assets/js/rtc.js
@@ -75,8 +75,8 @@ function sendMsg(msg, local) {
   //add localchat
   h.addChat(data, "local");
 }
-
-window.onbeforeunload = function () {
+var _ev = h.isiOS() ? 'pagehide' : 'beforeunload';
+window.addEventListener(_ev,function () {
   presence.leave();
   pcmap.forEach((pc, id) => {
     if (pcmap.has(id)) {
@@ -84,7 +84,7 @@ window.onbeforeunload = function () {
       pcmap.delete(id);
     }
   });
-};
+});
 
 function initPresence() {
   presence = new Presence(root, room);

--- a/src/assets/js/rtc.js
+++ b/src/assets/js/rtc.js
@@ -88,7 +88,7 @@ window.addEventListener(_ev,function () {
 
 function initPresence() {
   presence = new Presence(root, room);
-  damSocket.__proto__.presence = presence;
+  damSocket.setPresence(presence);
   presence.enter();
 }
 


### PR DESCRIPTION
Here's `EventEmitter` refactored so that it actually has `.on` for adding listeners and `.emit` to dispatch events. This refactor was needed, because (Edge/Opera/Safari to some extent) doesn't approve unannounced adhoc `Class.onThisAndThat(data)`     

Also added some feature detecting to src/js/helpers.js for oldEdge,Edge and if we have MediaStream constructor in window (safari).

- These changes enabled even older Edge to send videostream to FF and Chrome desktop versions, even the user doesn't see others except for placeholders, the chat is usable, so this is a starting point for issues #56 and #60 

Comments, testing and feedback appreciated.