### PR TITLE
#79 wrap the action in try catch for FF

### DIFF
--- a/src/assets/js/helpers.js
+++ b/src/assets/js/helpers.js
@@ -351,21 +351,25 @@ export default {
   },
 
   addVideoElementEvent(elem, type = "pip") {
-    if ("pictureInPictureEnabled" in document 
-      && typeof elem.requestPictureInPicture === 'function' 
+    if ("pictureInPictureEnabled" in document  
       && type == "pip") {
       elem.addEventListener("dblclick", (e) => {
         e.preventDefault();
-        if (!document.pictureInPictureElement) {
-          elem.requestPictureInPicture().catch((error) => {
-            // Video failed to enter Picture-in-Picture mode.
-            console.error(error);
-          });
-        } else {
-          document.exitPictureInPicture().catch((error) => {
-            // Video failed to leave Picture-in-Picture mode.
-            console.error(error);
-          });
+        try {
+          if (!document.pictureInPictureElement) {
+            elem.requestPictureInPicture().catch((error) => {
+              // Video failed to enter Picture-in-Picture mode.
+              console.error(error);
+            });
+          } else {
+            document.exitPictureInPicture().catch((error) => {
+              // Video failed to leave Picture-in-Picture mode.
+              console.error(error);
+            });
+          }
+        } catch (err) {
+          console.warn("pip failure?",err);
+          //noop 
         }
       });
     } else {


### PR DESCRIPTION
As firefox *doesn't* expose the HTMLVideoElement.requestPictureInPicture method to DOM we'll need to wrap this to try-catch block

Test this change, and if it works, we can ship it directly.

Closes: #79 