### PR TITLE
EventEmitter pure and old EventEmitter renamed to DamEventEmitter 

### DIFF
--- a/src/assets/js/ee.js
+++ b/src/assets/js/ee.js
@@ -1,0 +1,18 @@
+export default class EventEmitter {
+  constructor() {
+    this.listeners = {};
+    return this;
+  }
+  on(event,cb){
+    if(!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(cb);
+    return this;
+  }
+  emit(event,data){
+    let cbs = this.listeners[event];
+    if(cbs){
+      cbs.forEach(cb => cb(data))
+    }
+    return this;
+  }
+}

--- a/src/assets/js/emitter.js
+++ b/src/assets/js/emitter.js
@@ -1,4 +1,4 @@
-import {EventEmitter} from './ee.js';
+import EventEmitter from './ee.js';
 export default class DamEventEmitter extends EventEmitter {
   constructor(gun, room) {
     super();

--- a/src/assets/js/emitter.js
+++ b/src/assets/js/emitter.js
@@ -1,17 +1,11 @@
-export default class EventEmitter {
+import {EventEmitter} from './ee.js';
+export default class DamEventEmitter extends EventEmitter {
   constructor(gun, room) {
-    this.listeners = {};
+    super();
     this.presence = null;
     this.room = room;
     this.root = gun;
     this.init();
-    return this;
-  }
-  on(event,cb){
-    if(!this.listeners[event]) this.listeners[event] = [];
-    this.listeners[event].push(cb);
-    //Object.assign(this,{[event]:this.listeners[event]});
-    //console.log("added on event",event,"callback",cb,this);
     return this;
   }
   setPresence(presence){
@@ -19,14 +13,6 @@ export default class EventEmitter {
   }
   getPresence(){
     return this.presence ? this.presence : false;
-  }
-  emit(event,data){
-    //console.log("emitting event",event,"with data",data);
-    let cbs = this.listeners[event];
-    if(cbs){
-      cbs.forEach(cb => cb(data))
-    }
-    return this;
   }
   //Posible signaling events
   /*

--- a/src/assets/js/rtc.js
+++ b/src/assets/js/rtc.js
@@ -3,7 +3,8 @@
  * @date 6th January, 2020
  */
 import h from "./helpers.js";
-import EventEmitter from "./emitter.js";
+import EventEmitter from "./ee.js";
+import DamEventEmitter from "./emitter.js";
 import Presence from "./presence.js";
 import MetaData from "./metadata.js";
 var TIMEGAP = 6000;
@@ -134,7 +135,7 @@ function initRTC() {
       .querySelector("#username-set")
       .attributes.removeNamedItem("hidden");
   } else {
-    damSocket = new EventEmitter(root, room);
+    damSocket = new DamEventEmitter(root, room);
     initPresence();
     let commElem = document.getElementsByClassName("room-comm");
 


### PR DESCRIPTION
pure event emitter only has .on and .emit -core functions, DamEventEmitter has gun and room dependency, and other custom logic for gun.out etc so this way we have a clean EE abstraction for other related stuff