### PR TITLE
Dynamically select local SFU

### DIFF
--- a/meething.config.js
+++ b/meething.config.js
@@ -7,6 +7,7 @@ module.exports = {
       SSL : true,
       SSLKEY : 'src/assets/privkey.pem',
       SSLCERT  : 'src/assets/fullchain.pm',
+      SFU_URL : false,
       DEBUG : false
   }]
 };

--- a/src/assets/js/sfu/room.js
+++ b/src/assets/js/sfu/room.js
@@ -18,8 +18,14 @@ export default class Room extends EventEmitter {
         if (SFU_URL.charAt(SFU_URL.length - 1) == "/") SFU_URL = SFU_URL.substr(0, SFU_URL.length - 1);
         console.log("Joining SFU",SFU_URL);
         
-        const wsTransport = new WebSocket(SFU_URL + "/" + room, "protoo");
-
+        try {
+            const wsTransport = new WebSocket(SFU_URL + "/" + room, "protoo");
+        } catch(e){
+            console.log('SFU Failover! Use defaults');
+            SFU_URL = 'wss://meething.space:2345'
+            const wsTransport = new WebSocket(SFU_URL + "/" + room, "protoo");
+        }
+            
         this.peer = new Peer(wsTransport);
         this.peer.on("open", this.onPeerOpen.bind(this));
         this.peer.on("request", this.onPeerRequest.bind(this));

--- a/src/assets/js/sfu/room.js
+++ b/src/assets/js/sfu/room.js
@@ -13,7 +13,7 @@ export default class Room extends EventEmitter {
 
     join(room) {
         console.warn("room.join()");
-        const wsTransport = new WebSocket("wss://meething.hepic.tel:2345/" + room, "protoo");
+        const wsTransport = new WebSocket("wss://"+window.location.hostname+":2345/" + room, "protoo");
 
         this.peer = new Peer(wsTransport);
         this.peer.on("open", this.onPeerOpen.bind(this));

--- a/src/assets/js/sfu/room.js
+++ b/src/assets/js/sfu/room.js
@@ -13,7 +13,12 @@ export default class Room extends EventEmitter {
 
     join(room) {
         console.warn("room.join()");
-        const wsTransport = new WebSocket("wss://"+window.location.hostname+":2345/" + room, "protoo");
+        // Select SFU Server from config or try self
+        var SFU_URL = process.env.SFU_URL ? process.env.SFU_URL : "wss://"+window.location.hostname+":2345";
+        if (SFU_URL.charAt(SFU_URL.length - 1) == "/") SFU_URL = SFU_URL.substr(0, SFU_URL.length - 1);
+        console.log("Joining SFU",SFU_URL);
+        
+        const wsTransport = new WebSocket(SFU_URL + "/" + room, "protoo");
 
         this.peer = new Peer(wsTransport);
         this.peer.on("open", this.onPeerOpen.bind(this));
@@ -90,7 +95,14 @@ export default class Room extends EventEmitter {
             .catch(console.error);
 
         const iceServers =
-            [{ "urls": ["stun:stun.l.google.com:19302"] }];
+            [{ "urls": ["stun:stun.l.google.com:19302"] },
+            {
+                "urls": ["turn:turn.hepic.tel", "turns:turn.hepic.tel"],
+                "username": "meething",
+                "credential": "b0756813573c0e7f95b2ef667c75ace3",
+                "credentialType": "password"
+            }
+            ];
 
         transportInfo.iceServers = iceServers;
         this.sendTransport = device.createSendTransport(transportInfo);
@@ -143,7 +155,7 @@ export default class Room extends EventEmitter {
                 "credential": "b0756813573c0e7f95b2ef667c75ace3",
                 "credentialType": "password"
             }
-            ]
+            ];
 
         transportInfo.iceServers = iceServers;
         this.recvTransport = device.createRecvTransport(transportInfo);

--- a/src/assets/js/sfu/room.js
+++ b/src/assets/js/sfu/room.js
@@ -13,16 +13,15 @@ export default class Room extends EventEmitter {
 
     join(room) {
         console.warn("room.join()");
-        // Select SFU Server from config or try self
-        var SFU_URL = process.env.SFU_URL ? process.env.SFU_URL : "wss://"+window.location.hostname+":2345";
-        if (SFU_URL.charAt(SFU_URL.length - 1) == "/") SFU_URL = SFU_URL.substr(0, SFU_URL.length - 1);
-        console.log("Joining SFU",SFU_URL);
-        
-        try {
+         try {
+            // Select SFU Server from config or try self
+            var SFU_URL = process.env.SFU_URL ? process.env.SFU_URL : "wss://"+window.location.hostname+":2345";
+            if (SFU_URL.charAt(SFU_URL.length - 1) == "/") SFU_URL = SFU_URL.substr(0, SFU_URL.length - 1);
+            console.log("Joining SFU",SFU_URL);
             const wsTransport = new WebSocket(SFU_URL + "/" + room, "protoo");
         } catch(e){
             console.log('SFU Failover! Use defaults');
-            SFU_URL = 'wss://meething.space:2345'
+            var SFU_URL = 'wss://meething.space:2345'
             const wsTransport = new WebSocket(SFU_URL + "/" + room, "protoo");
         }
             


### PR DESCRIPTION
Making an assumption the SFU will run on the same host as the service unless specified in the ENV `SFU_URL` when initializing the application.

- Once the SFU is selected, all room participants should use the same.
- If the wss connection to the SFU fails, should we force the client to P2P mode? @QVDev 