### PR TITLE
New options start muted hidden (Confirm it does not break stuff before merging)

### DIFF
--- a/src/assets/js/connection.js
+++ b/src/assets/js/connection.js
@@ -102,6 +102,23 @@ export default class Connection {
           med.h.showNotification(notification);
         }
       }
+      else if (data.subEvent == "video-mute") {
+        if (data.muted) {
+          var notification = data.username + " is hiding";
+          med.h.showNotification(notification);
+          const widget = document.getElementById(`${data.socketId}-widget`);
+          if (widget) {
+            widget.hidden = true;
+          }
+        } else {
+          var notification = data.username + " is back"
+          med.h.showNotification(notification);
+          const widget = document.getElementById(`${data.socketId}-widget`);
+          if (widget) {
+            widget.hidden = false;
+          }
+        }
+      }
     } else if (data.event == "control") {
       if (data.username && data.socketId) {
         med.h.swapUserDetails(data.socketId + "-title", data);

--- a/src/assets/js/sfu/room.js
+++ b/src/assets/js/sfu/room.js
@@ -44,10 +44,11 @@ export default class Room extends EventEmitter {
         console.log(this.peer.id);
     }
 
-    async sendAudio(track) {
+    async sendAudio(track, data) {
         console.warn("room.sendAudio()");
         const audioProducer = await this.sendTransport.produce({
-            track: track
+            track: track,
+            appData: data
         });
         audioProducer.on("trackended", async () => {
             console.warn("producer.close() by trackended");
@@ -56,10 +57,11 @@ export default class Room extends EventEmitter {
         return audioProducer;
     }
 
-    async sendVideo(track) {
+    async sendVideo(track, data) {
         console.warn("room.sendVideo()");
         const videoProducer = await this.sendTransport.produce({
             track: track,
+            appData: data,
             encodings:
                 [
                     { maxBitrate: 90000 },

--- a/src/assets/js/sfu/sfu.js
+++ b/src/assets/js/sfu/sfu.js
@@ -61,17 +61,20 @@ export default class SFU extends EventEmitter {
             try {
                 this.broadcasting = true;
                 const video = this.config.localVideoEl;
+                const appdata = {audioMuted:false, audioMuted:false}
                 if (peerCount > 4) {
                     video.srcObject.getVideoTracks()[0].enabled = false;
                     document.getElementById("toggle-video").click()
+                    appdata.videoMuted = true;
                 }
                 if (peerCount > 12) {
                     video.srcObject.getAudioTracks()[0].enabled = false;
                     document.getElementById("toggle-mute").click()
+                    appdata.audioMuted = true;
                 }
 
-                this.videoProducer = await this.sfuRoom.sendVideo(video.srcObject.getVideoTracks()[0]);
-                this.audioProducer = await this.sfuRoom.sendAudio(video.srcObject.getAudioTracks()[0]);
+                this.videoProducer = await this.sfuRoom.sendVideo(video.srcObject.getVideoTracks()[0], appdata);
+                this.audioProducer = await this.sfuRoom.sendAudio(video.srcObject.getAudioTracks()[0], appdata);
 
                 var self = this;
                 // Attach SoundMeter to Local Stream
@@ -135,6 +138,9 @@ export default class SFU extends EventEmitter {
         var video = document.getElementById(consumer._appData.peerId + "-video");
         if (video == undefined) {
             video = helper.addVideo(consumer._appData.peerId);
+            if(consumer._appData.videoMuted) {
+                video.parentElement.hidden = true;
+            }
             return video;
         } else if (video.srcObject.getVideoTracks().length > 0 && consumer._track.kind == "video") {
             video = helper.addVideo(`${consumer._id}`);

--- a/src/assets/js/ui/toggles.js
+++ b/src/assets/js/ui/toggles.js
@@ -22,11 +22,13 @@ export default class Toggles {
         med.videoMuted = true;
         e.srcElement.classList.remove("fa-video");
         e.srcElement.classList.add("fa-video-slash");
+        med.metaData.sendNotificationData({ username: med.username, subEvent: "video-mute", muted: med.videoMuted });
         med.h.showNotification("Video Disabled");
       } else {
         med.videoMuted = false;
         e.srcElement.classList.add("fa-video");
         e.srcElement.classList.remove("fa-video-slash");
+        med.metaData.sendNotificationData({ username: med.username, subEvent: "video-mute", muted: med.videoMuted });
         med.h.showNotification("Video Enabled");
       }
       window.ee.emit("video-toggled")


### PR DESCRIPTION
@Dletta @jabis @lmangani I added magic to hide users when muted to make sure townhall is not showing 150+ people in small squared bacon strips. Its hackyish but seems to work in my testing. Let me know if we will add this feature.