### PR TITLE
Add option to join an extra SFU this will combine multiple SFU's

### DIFF
--- a/src/assets/js/sfu/sfu.js
+++ b/src/assets/js/sfu/sfu.js
@@ -62,6 +62,10 @@ export default class SFU extends EventEmitter {
         this.sfuRoom.join(room, peerId);
     }
 
+    connect(url, peerId) {
+        this.sfuRoom.joinExtraSFU(this.room, peerId, url);
+    }
+
     async startBroadcast(peerCount) {
         if (!this.broadcasting) {
             try {

--- a/src/assets/js/sfu/video.js
+++ b/src/assets/js/sfu/video.js
@@ -132,6 +132,11 @@ export default class Video {
       webrtc.changeStream(stream);
     });
 
+    med.ee.on('connect:sfu', function (url) {
+      console.log(`connect to ${url} as extra SFU`);
+      webrtc.connect(url, med.socketId);
+    });
+
     webrtc.init();
   }
 }


### PR DESCRIPTION
It will only send out video/audio to primary SFU and listens to the extra SFU.

You type in the console ee.emit("connect:sfu", "wss://sfu-url:port")
this will add you as a listener and able to receive incoming video/audio in order for those client to connect with you they should connect to your SFU as well.